### PR TITLE
Remove conditional comment with broken link 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,9 +26,5 @@
   <link rel="stylesheet" href="/assets/normalize.css" />
   <link rel="stylesheet" href="/assets/animate.css" />
   <link rel="stylesheet" href="/assets/styles.css" />
-
-  <!--[if lt IE 9]>
-    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-  <![endif]-->
 </head>  
 


### PR DESCRIPTION
Hello friend,
I am writing you from the year 2020. 🤖 🚀

Bad news: There are still no hoverboards like predicted in Back to the Future. 😔

Good news: IE8 und Google Code are gone for good. 🎉

----

**About this change**

This removes the conditional comment for Internet Explorer browsers version 8 and below.
It included an ancient polyfill for the proper rendering of HTML5 elements in these older browsers.

Due to the insignificant market share of these browsers (< 0.3%) and since the URL to the polyfill is pointing to a non-existing resource, this PR removes this code altogether.