### PR TITLE
Create imprint page skeleton

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer>
 <div class="copyright">
   <a href="mailto:{{ site.email }}" title="Send E-Mail">Contact</a> |
-  <a href="/impressum">Impressum</a> |
+  <a href="/imprint">Imprint</a> |
   <a href="/code-of-conduct">Code of Conduct</a>
 </div>
 </footer>

--- a/imprint.md
+++ b/imprint.md
@@ -1,0 +1,8 @@
+---
+layout: page
+header_image: "header-imprint.jpg"
+summary: This is the summary text for the imprint page.
+title: Imprint
+---
+
+Imprint text goes here...

--- a/index.md
+++ b/index.md
@@ -15,14 +15,14 @@ If you'd like to get notified once we open our registration, please leave your e
 
 We will use your provided email address only for the purpose of sending you an email, informing you about the
 opening registration of #humansconf opens. We will never share your email address with other parties, and handle it,
-according to our [privacy policy](/impressum).
+according to our [privacy policy](/imprint).
 
 ## Our Vision
 
 Successful technology products tell a story about humans who came together to solve complex problems that
 touch people’s lives. It’s a story of collaboration, sharing, communication and empathy. But more often than
 not, this side of the story gets overlooked in favour of programming languages or frameworks — even though
-it’s the one piece of the puzzle all successful projects have in common. 
+it’s the one piece of the puzzle all successful projects have in common.
 
 We aim to bring together people from all kinds of backgrounds and roles to discuss, share, and celebrate the
 stories and lessons learnt when humans come together.


### PR DESCRIPTION
Not sure if this is important right now, but it fixes a couple of dead links on the page so I thought, why not. 🤓

This commit bundles a couple or related changes:
- Translates "Impressum" to English to match the rest of the page
- Create skeleton imprint page
- Updates links accordingly