### PR TITLE
Use https for import URLs

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,6 +1,6 @@
 /* Google Webfonts */
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600);
-@import url(http://fonts.googleapis.com/css?family=Karla:700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600);
+@import url(https://fonts.googleapis.com/css?family=Karla:700);
 
 /* Fallback */
 header, footer, section, article, nav, aside { display: block }


### PR DESCRIPTION
Chrome will not load http resources if page is viewed via https.

![screenshot-2020-02-09T170550](https://user-images.githubusercontent.com/188915/74105791-3cab6d80-4b61-11ea-9b4b-19a3a1fa0c79.png)
